### PR TITLE
Abbreviated Pagination

### DIFF
--- a/gallery.css
+++ b/gallery.css
@@ -132,3 +132,11 @@ footer {
     width: 90%;
     text-align: center;
 }
+
+.paginationLowerContainer {
+	margin-bottom: 20px;
+    margin-left: auto;
+    margin-right: auto;
+    width: 90%;
+    text-align: center;
+}

--- a/gallery.php
+++ b/gallery.php
@@ -67,7 +67,7 @@ function outputGallery() {
 }
 
 //Function that prints the pagination
-function outputPagination() {
+function outputPaginationLower() {
 	global $images;
 	global $imagesPerPage;
 	$pageNr = intval($_GET["page"]);
@@ -94,6 +94,52 @@ function outputPagination() {
 		if (($pageNr + 1) <= $nrOfPages) {
 			echo '<li class="arrow"><a href="?page='.($pageNr + 1).'">></a></li>';
 		}
+
+	}
+}
+
+//Function that prints the abbreviated pagination
+function outputPagination() {
+	global $images;
+	global $imagesPerPage;
+	$pageNr = intval($_GET["page"]);
+
+	if ($pageNr == '') {
+		$pageNr = 1;
+	}
+
+	$nrOfPages = ceil(sizeof($images)/$imagesPerPage);
+
+	if ($nrOfPages > 1) {
+		if ($pageNr > 0 && $pageNr != 1) {
+			if ($pageNr >= 3) {
+				echo '<li class="arrow"><a href="?page=1"><<</a></li>';
+			}
+			echo '<li class="arrow"><a href="?page='.($pageNr - 1).'"><</a></li>';
+		}
+
+		for ($i = -2; $i <= 2; $i++) {
+			$finalPageNum = $pageNr + $i;
+			if ($finalPageNum <= 0) {
+				//Draw nothing
+			} else if ($finalPageNum <= $nrOfPages) {
+				if ($i == 0) {
+					echo '<li class="active"><a href="?page='.$finalPageNum.'">'.$finalPageNum.'</a></li>';
+				} else {
+					echo '<li><a href="?page='.$finalPageNum.'">'.$finalPageNum.'</a></li>';
+				}	
+			}
+			
+					
+		}
+		
+		if (($pageNr + 3) <= $nrOfPages) {
+			echo '<li class="arrow"><a href="?page='.($pageNr + 1).'">></a></li>';
+			if (($pageNr+4) <= $nrOfPages) {
+				echo '<li class="arrow"><a href="?page='.($nrOfPages).'">>></a></li>';
+			}
+		}
+		
 
 	}
 }

--- a/index.php
+++ b/index.php
@@ -40,8 +40,13 @@ include('gallery.php');
 
 		<div class="imageContainer">
 		<?php outputGallery(); ?>
-		</div>	
+		</div>
 
+		<div class="paginationLowerContainer">
+                        <ul>
+                        <?php outputPaginationLower(); ?>
+                        </ul>
+                </div>
 		<footer>
 			Es befinden sich <em><?php outputNumberOfImages(); ?></em> Bilder in dieser Gallerie.
 		</footer>


### PR DESCRIPTION
Added an abbreviated pagination above the pictures. Extended pagination is now below the pictures. 
If you are on page one the abbreviated pagination shows:
"1 2 3 > >>"
As usual, the single arrow takes you to the next page, the double arrow takes you to the last page.
If you are on page five it would show as:
"<< < 3 4 5 6 7 > >>"
And on the last page (here 10) :
"<< < 8 9 10"